### PR TITLE
deps: ツールチェインを最新の nightly へ更新

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-08-05"
+channel = "stable"
 components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "nightly-2023-12-27"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
#75 のログを見たところ, 最新の serenity が Rust 1.74 以上でのみ動作するようになっていたので, `rust-toolchain.toml` を更新してみました. もし不都合があればお知らせください.