### PR TITLE
fix: flip the default order

### DIFF
--- a/src/bot/meigen/mod.rs
+++ b/src/bot/meigen/mod.rs
@@ -20,9 +20,9 @@ pub enum SortKey {
 #[derive(ValueEnum, Clone, Debug, PartialEq, Eq, Default)]
 pub enum SortDirection {
     #[clap(alias = "a")]
-    #[default]
     Asc,
     #[clap(alias = "d")]
+    #[default]
     Desc,
 }
 
@@ -140,7 +140,7 @@ enum Command {
         #[clap(value_enum, long, default_value_t)]
         dir: SortDirection,
 
-        /// 降順にします。--dir desc のエイリアスです。
+        /// 降順にします。--dir asc のエイリアスです。
         #[clap(short = 'R', long, alias = "rev")]
         #[clap(default_value_t = false)]
         reverse: bool,
@@ -203,7 +203,7 @@ impl<R: Runtime, D: MeigenDatabase> BotService<R> for MeigenBot<D> {
                     offset,
                     limit,
                     sort,
-                    dir: if reverse { SortDirection::Desc } else { dir },
+                    dir: if reverse { SortDirection::Asc } else { dir },
                     random,
                 })
                 .await?

--- a/src/bot/meigen/mod.rs
+++ b/src/bot/meigen/mod.rs
@@ -394,3 +394,56 @@ fn test_format_ferris() {
         "```\n------------------------\n   abcdeあいうえおdddあ\n    --- あいうえお\n------------------------\n       \\\n        \\\n         \\\n            _~^~^~_\n        \\) /  o o  \\ (/\n          '_   -   _'\n          / '-----' \\\n\n```"
     );
 }
+
+#[cfg(test)]
+#[tokio::test]
+async fn test_integration() {
+    use crate::client::test::*;
+
+    let db = crate::db::mem::MemoryDB::new();
+    let meigen = MeigenBot::new(db);
+
+    let snapshot = "
+> g!meigen make author1 hey
+Meigen No.1
+```
+hey
+    --- author1
+```
+
+> g!meigen make author2 hello
+Meigen No.2
+```
+hello
+    --- author2
+```
+
+> g!meigen list
+Meigen No.2
+```
+hello
+    --- author2
+```
+Meigen No.1
+```
+hey
+    --- author1
+```
+
+
+> g!meigen list -R
+Meigen No.1
+```
+hey
+    --- author1
+```
+Meigen No.2
+```
+hello
+    --- author2
+```
+    "
+    .trim();
+
+    run(meigen, snapshot).await;
+}

--- a/src/bot/meigen/model.rs
+++ b/src/bot/meigen/model.rs
@@ -49,14 +49,14 @@ impl std::fmt::Display for Meigen {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let loves = self.loves();
         let loves_description = if loves > 0 {
-            format!("(♥ x{loves})")
+            format!(" (♥ x{loves})")
         } else {
             String::new()
         };
 
         write!(
             f,
-            "Meigen No.{} {}
+            "Meigen No.{}{}
 ```
 {}
     --- {}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -8,6 +8,9 @@ pub mod console;
 #[cfg(feature = "discord_client")]
 pub mod discord;
 
+#[cfg(test)]
+pub mod test;
+
 pub trait ServiceVisitor<R: Runtime>: Send + Sync {
     fn visit(&self, service: &impl BotService<R>) -> impl Future<Output = ()> + Send;
 }

--- a/src/client/test.rs
+++ b/src/client/test.rs
@@ -1,0 +1,121 @@
+use {
+    crate::bot::{Attachment, BotService, Context, Message, Runtime, SendMessage, User},
+    anyhow::Result,
+    pretty_assertions::*,
+    std::sync::Mutex,
+};
+
+pub struct TestRuntime;
+impl Runtime for TestRuntime {
+    type Message = TestMessage;
+    type Context = TestContext;
+}
+
+pub struct TestUser;
+impl User for TestUser {
+    fn id(&self) -> u64 {
+        todo!()
+    }
+    fn name(&self) -> &str {
+        todo!()
+    }
+    async fn dm(&self, _msg: SendMessage<'_>) -> Result<()> {
+        todo!()
+    }
+}
+pub struct TestAttachment;
+impl Attachment for TestAttachment {
+    fn name(&self) -> &str {
+        todo!()
+    }
+    fn size(&self) -> usize {
+        todo!()
+    }
+    async fn download(&self) -> Result<Vec<u8>> {
+        todo!()
+    }
+}
+
+pub struct TestContext {
+    pub msg: Mutex<Vec<String>>,
+}
+impl Context for TestContext {
+    async fn send_message(&self, msg: SendMessage<'_>) -> Result<()> {
+        assert!(
+            msg.attachments.is_empty(),
+            "todo: attachments not supported"
+        );
+        self.msg.lock().unwrap().push(msg.content.to_owned());
+        Ok(())
+    }
+    async fn get_user_name(&self, _user_id: u64) -> Result<String> {
+        todo!()
+    }
+    async fn is_bot(&self, _user_id: u64) -> Result<bool> {
+        todo!()
+    }
+}
+pub struct TestMessage {
+    pub author: TestUser,
+    pub content: String,
+}
+impl Message for TestMessage {
+    type Attachment = TestAttachment;
+    type User = TestUser;
+
+    async fn reply(&self, _msg: &str) -> Result<()> {
+        todo!()
+    }
+    fn author(&self) -> &Self::User {
+        &self.author
+    }
+    fn content(&self) -> &str {
+        &self.content
+    }
+    fn attachments(&self) -> &[Self::Attachment] {
+        todo!()
+    }
+}
+
+pub async fn run(service: impl BotService<TestRuntime>, snapshot: &str) {
+    let mut lines = snapshot.lines().peekable();
+    while let Some(input) = lines.next() {
+        let input = input.trim();
+        if input.is_empty() {
+            continue;
+        }
+
+        let Some(input) = input.strip_prefix("> ") else {
+            panic!("should be start with '> ': {input}")
+        };
+
+        let msg = TestMessage {
+            author: TestUser,
+            content: input.trim().to_owned(),
+        };
+
+        let ctx = TestContext {
+            msg: Mutex::new(vec![]),
+        };
+
+        service.on_message(&msg, &ctx).await.unwrap();
+
+        let mut expected_output = vec![];
+        while matches!(lines.peek(), Some(s) if !s.starts_with("> ")) {
+            expected_output.push(lines.next().unwrap())
+        }
+
+        let expected_output = expected_output.join("\n");
+        let expected_output = expected_output.trim();
+
+        let actual_contents = ctx.msg.into_inner().unwrap();
+
+        self::assert_eq!(
+            actual_contents.len(),
+            1,
+            "handling for multiple/none output messages not implemented"
+        );
+
+        self::assert_eq!(expected_output, actual_contents[0]);
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "memory_db")]
+#[cfg(any(test, feature = "memory_db"))]
 pub mod mem;
 
 #[cfg(feature = "mongo_db")]


### PR DESCRIPTION
テストが動かせず号泣しています　IT 弱者かも 🫨 

```
  --- stderr
  /usr/include/bits/floatn.h:97:9: error: __float128 is not supported on this target

  thread 'main' panicked at /home/flisan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bindgen-0.68.1/lib.rs:888:13:
  assertion `left == right` failed: "x86_64-unknown-linux-gnu" "x86_64-unknown-linux-gnu"
    left: 4
   right: 8
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```